### PR TITLE
Add ping test and mocha setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron-forge start",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish"
@@ -22,7 +22,8 @@
     "@electron-forge/plugin-fuses": "^7.8.1",
     "@electron-forge/publisher-github": "^7.8.1",
     "@electron/fuses": "^1.8.0",
-    "electron": "^36.5.0"
+    "electron": "^36.5.0",
+    "mocha": "^10.4.0"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",

--- a/test/ping.test.js
+++ b/test/ping.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const Module = require('module');
+
+describe('preload ping', function () {
+  it('returns pong', async function () {
+    const electronMock = {
+      ipcRenderer: {
+        invoke: async (channel) => {
+          assert.strictEqual(channel, 'ping');
+          return 'pong';
+        }
+      },
+      contextBridge: {
+        exposeInMainWorld: (key, api) => {
+          global[key] = api;
+        }
+      }
+    };
+
+    const originalLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+      if (request === 'electron') {
+        return electronMock;
+      }
+      return originalLoad(request, parent, isMain);
+    };
+
+    delete require.cache[require.resolve('../preload.js')];
+    require('../preload.js');
+    Module._load = originalLoad;
+
+    const result = await global.versions.ping();
+    assert.strictEqual(result, 'pong');
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha as a dev dependency and update the `test` script
- implement `test/ping.test.js` to verify the `ping` function

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fafac70e48326943a4639678a0bd8