### PR TITLE
Fix version references in renderer

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1,5 +1,5 @@
 const information = document.getElementById('info')
-information.innerText = `This app is using Chrome (v${versions.chrome()}), Node.js (v${versions.node()}), and Electron (v${versions.electron()})`
+information.innerText = `This app is using Chrome (v${window.versions.chrome()}), Node.js (v${window.versions.node()}), and Electron (v${window.versions.electron()})`
 
 const func = async () => {
   const response = await window.versions.ping()


### PR DESCRIPTION
## Summary
- use `window.versions` when displaying runtime versions

## Testing
- `npm test`
- `npx electron-forge start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_685fafd8a91c8326b428d44a4f3d1a6d