### PR TITLE
release: v1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-electron-app",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-electron-app",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-electron-app",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "my first electron app",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump version to 1.0.8
- tag `v1.0.8` for the release workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff303cfb08326a499cb80af194d9b