### PR TITLE
Fix release workflow for cross platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  release-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm install
+      - run: npm test
+      - run: npm run publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: sudo apt-get update && sudo apt-get install -y dpkg fakeroot rpm
       - run: npm install
       - run: npm test
       - run: npm run publish

--- a/forge.config.js
+++ b/forge.config.js
@@ -18,10 +18,12 @@ module.exports = {
     {
       name: '@electron-forge/maker-deb',
       config: {},
+      platforms: ['linux']
     },
     {
       name: '@electron-forge/maker-rpm',
       config: {},
+      platforms: ['linux']
     },
   ],
   plugins: [


### PR DESCRIPTION
## Summary
- restrict Linux package makers to run on Linux
- build Windows and Linux release packages in separate jobs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68602abbf6248326b25d086fa6364611