### PR TITLE
Fix Windows release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  create-release:
-    needs:
-      - release-windows
-      - release-linux
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false


### PR DESCRIPTION
## Summary
- remove the final `create-release` job so Electron Forge's GitHub publisher can attach installers to the release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68603d9235048326a121dca22869ad8b